### PR TITLE
Bug Fixes and TRLE Net ID Inclusion

### DIFF
--- a/src/TRCustoms.cs
+++ b/src/TRCustoms.cs
@@ -18,7 +18,7 @@ namespace TRLEManager
 		public const string TRCustomsJSONInfoPageTemplate = TRCustomsURL + "/api/levels/{0}";
 		public const string TRCustomsInfopageURLTemplate = TRCustomsURL + "/levels/{0}";
 		//public const string TRCustomsDownloadURLTemplate = TRCustomsURL + "/api/level_files/{0}/download";
-		public const string TRCustomsWalkthroughURLTemplate = TRCustomsURL + "/api/level_files/{0}/download";
+		public const string TRCustomsWalkthroughURLTemplate = TRCustomsURL + "/levels/{0}/walkthroughs";
 
 		public uint ID { get; private set; }
 		public string Title { get; private set; }
@@ -26,8 +26,9 @@ namespace TRLEManager
 		public string WebpageURL { get; private set; }
 		public string DownloadURL { get; private set; }
 		public string WalkthroughURL { get; private set; }
+		public uint TRLENetID { get; private set; }
 
-		public static TRCustomsInfo CreateFromInfoPage(string infopage)
+        public static TRCustomsInfo CreateFromInfoPage(string infopage)
 		{
 			var result = new TRCustomsInfo();
 
@@ -39,11 +40,14 @@ namespace TRLEManager
 			result.Title = jsonObject["name"]?.ToString();
 			uint.TryParse(acquiredTRCustomsID, out uint trCustomsID);
 			result.ID = trCustomsID;
-
 			
 			result.WalkthroughURL = string.Format(TRCustomsWalkthroughURLTemplate, trCustomsID);
 
-			var authors = jsonObject["authors"] as JArray;
+            string acquiredTRLENetID = jsonObject["trle_id"]?.ToString();
+            uint.TryParse(acquiredTRLENetID, out uint trleNetID);
+			result.TRLENetID = trleNetID;
+
+            var authors = jsonObject["authors"] as JArray;
 
 			StringBuilder concat_authors = new StringBuilder();
 			foreach (object author in authors) {

--- a/src/TRLEInfoEntryWindow.xaml.cs
+++ b/src/TRLEInfoEntryWindow.xaml.cs
@@ -112,6 +112,7 @@ namespace TRLEManager
 				TextBox_InfoWebpage.Text = info.WebpageURL;
 				TextBox_DownloadURL.Text = info.DownloadURL;
 				TextBox_WalkthroughURL.Text = info.WalkthroughURL;
+				TextBox_TRLENetID.Text = info.TRLENetID.ToString();
 			}
 			catch (Error e)
 			{

--- a/src/ZipFileAlt.cs
+++ b/src/ZipFileAlt.cs
@@ -14,6 +14,10 @@ namespace TRLEManager
                 {
                     var destinationPath = Path.Combine(destinationDirectoryName, entry.FullName);
                     var isFile = !string.IsNullOrEmpty(Path.GetExtension(destinationPath));
+                    var directoryName = Path.GetDirectoryName(destinationPath);
+
+                    if(!Directory.Exists(directoryName))
+                        Directory.CreateDirectory(Path.GetDirectoryName(destinationPath));
 
                     if (!isFile)
                     {


### PR DESCRIPTION
1. Walkthrough URL was incorrect
2. TRLE Net ID is now extracted from TR Customs and included in Data
3. Issue where if a Directory did not exist on extract and error was thrown